### PR TITLE
fix: support run command with args in runguard

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -14,12 +14,14 @@ mkdir -p ./bin/
 rm -rf ./bin/python3
 echo "Extracting Python (IGNORE ERRORS, IT'll STILL WORK :D)..."
 tar -xzf python.tar.gz -C ./tmp/
-mv ./tmp/python/bin/ ./bin/python3
+mv ./tmp/python/ ./bin/python3
 # Cleanup
 rm -rf tmp python.tar.gz
 
 # Setup rust (MUST HAVE RUST INSTALLED THORUGH RUSTUP ALREADY)
-cp -r $HOME/.rustup/toolchains/stable-*-linux-gnu/bin bin/rust
+cp -r $HOME/.rustup/toolchains/stable-*-linux-gnu bin/rust
+# Removes unnecessary files
+rm -rf bin/rust/share/
 
 if [ ! -d "vcpkg" ]; then
     git clone https://github.com/microsoft/vcpkg.git --depth 1

--- a/src/modules/python.hpp
+++ b/src/modules/python.hpp
@@ -8,7 +8,10 @@ namespace modules {
     private:
 
         void compile() override {
-            return;
+            if (submission.status != data::submission_status::Running) return;
+            std::ofstream source_file(work_dir + "/main.py", std::ios::binary);
+            source_file << submission.file_content;
+            source_file.close();
         }
 
         void test(const std::string& input, const std::string& output) override {

--- a/src/modules/python.hpp
+++ b/src/modules/python.hpp
@@ -20,6 +20,9 @@ namespace modules {
                     if (!utils::token_compare(output_stream, output))
                         submission.status = data::submission_status::WrongAnswer;
                     else return;
+                } else if (WEXITSTATUS(run_guard.status) == EXIT_FAILURE) {
+                    submission.status = data::submission_status::RuntimeError;
+                    submission.message = run_guard.message;
                 }
             }
             else if (WIFSIGNALED(run_guard.status)) {

--- a/src/utils/runguard.hpp
+++ b/src/utils/runguard.hpp
@@ -43,7 +43,24 @@ namespace utils {
 				dup2(pipe_in[0], STDIN_FILENO);
 				dup2(pipe_out[1], STDOUT_FILENO);
 
-				char* args[] = {const_cast<char*>(command), nullptr};
+				int arg_idx = 0;
+				int space_idx = 0;
+				int i = 0;
+				// char[32] probably enough to not get overflowed
+				char* args[3] = {new char[32], nullptr, nullptr};
+				for (i = 0; command[i] != '\0'; i++) {
+					args[arg_idx][i - space_idx] = command[i];
+					if (command[i] == ' ') {
+						args[arg_idx][i] = '\0';
+						arg_idx++;
+						args[arg_idx] = new char[32];
+						space_idx = i;
+					}
+				}
+				args[arg_idx][i - space_idx] = '\0';
+				if (!space_idx) {
+					args[0] = const_cast<char*>(command);
+				}
 
 				// Set resource limits
 				if (memory_limit_mb) {
@@ -60,7 +77,7 @@ namespace utils {
 					alarm(time_limit_secs);
 				}
 
-				execvp(command, args);
+				execvp(args[0], args);
 
 				exit(EXIT_FAILURE);
 			}

--- a/src/utils/runguard.hpp
+++ b/src/utils/runguard.hpp
@@ -54,7 +54,7 @@ namespace utils {
 						args[arg_idx][i] = '\0';
 						arg_idx++;
 						args[arg_idx] = new char[32];
-						space_idx = i;
+						space_idx = i + 1;
 					}
 				}
 				args[arg_idx][i - space_idx] = '\0';

--- a/start.sh
+++ b/start.sh
@@ -2,5 +2,7 @@
 
 ls -la .
 realpath .
-export PATH="$(realpath ./bin/python3/):$(realpath ./bin/rust/):$PATH"
+export PATH="$(realpath ./bin/python3/bin/):$(realpath ./bin/rust/bin/):$PATH"
+python3.13 --version
+rustc --version
 ./CodeSandbox


### PR DESCRIPTION
This PR fixes running command with args (e.g. `python3.13 main.py`) in runguard, and also add required libs by python and rust :pray: 
